### PR TITLE
Add a match expression

### DIFF
--- a/src/ast-string.ts
+++ b/src/ast-string.ts
@@ -14,6 +14,8 @@ export function nodeKindString(kind: NodeKind): string {
         case NodeKind.Select: return "Select"
         case NodeKind.Index: return "Index"
         case NodeKind.Projection: return "Projection"
+        case NodeKind.Match: return "Match"
+        case NodeKind.MatchClause: return "MatchClause"
     }
 }
 
@@ -46,5 +48,7 @@ export function dump(node: Node): string {
         case NodeKind.Index: return `${dump(node.target)}[${dump(node.index)}]`
         case NodeKind.Member: return `${node.name}: ${dump(node.value)}`
         case NodeKind.Projection: return `...${dump(node.value)}`
+        case NodeKind.Match: return `match { ${node.clauses.map(dump).join(", ")} }`
+        case NodeKind.MatchClause: return `${dump(node.pattern)} in ${dump(node.value)}`
     }
 }

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -11,6 +11,8 @@ export const enum NodeKind {
     Select,
     Index,
     Projection,
+    Match,
+    MatchClause,
 }
 
 export const enum LiteralKind {
@@ -112,6 +114,18 @@ export interface Projection {
     value: Expression
 }
 
+export interface Match {
+    kind: NodeKind.Match
+    target: Expression
+    clauses: MatchClause[]
+}
+
+export interface MatchClause {
+    kind: NodeKind.MatchClause
+    pattern: Expression
+    value: Expression
+}
+
 export type Expression =
     Literal |
     Reference |
@@ -121,10 +135,12 @@ export type Expression =
     Array |
     Record |
     Select |
-    Index
+    Index |
+    Match
 
 export type Node =
     Expression |
     Binding |
     Member |
-    Projection
+    Projection |
+    MatchClause

--- a/src/eval.spec.ts
+++ b/src/eval.spec.ts
@@ -1,53 +1,48 @@
-import { 
-    Array, Binding, Call, Expression, Index, Lambda, Let, LiteralInt, LiteralKind, Member, NodeKind, Projection, Record, Reference, Select } from "./ast"
+import {
+    Array, Binding, Call, Expression, Index, Lambda, Let, LiteralInt, LiteralKind, Match, MatchClause, Member, Node, NodeKind, Projection, Record, Reference, Select
+} from "./ast"
 import { evaluate } from "./eval"
 
 describe("eval", () => {
     it("can evaluate a literal", () => {
-        expect(evaluate(i(10))).toEqual(i(10))        
+        evx(i(10)).toEqual(i(10))
     })
     it("can call a lambda", () => {
-        expect(evaluate(c(l(["x"], r("x")), i(10)))).toEqual(i(10))
+        evx(c(l(["x"], r("x")), i(10))).toEqual(i(10))
     })
     it("can index", () => {
-        expect(evaluate(idx(a(i(1), i(2), i(3)), i(1)))).toEqual(i(2))
+        evx(idx(a(i(1), i(2), i(3)), i(1))).toEqual(i(2))
     })
     it("can select", () => {
-        expect(
-            evaluate(
-                sel(
-                    rec(
-                        m("one", i(1)),
-                        m("two", i(2))
-                    ),
-                    "two"
-                )
+        evx(
+            sel(
+                rec(
+                    m("one", i(1)),
+                    m("two", i(2))
+                ),
+                "two"
             )
         ).toEqual(i(2))
     })
     it("can let", () => {
-        expect(
-            evaluate(
-                lt(
-                    r("x"),
-                    b("x", i(1))
-                )
+        evx(
+            lt(
+                r("x"),
+                b("x", i(1))
             )
         ).toEqual(i(1))
     })
     it("can multi-let", () => {
-        expect(
-            evaluate(
-                lt(
-                    rec(
-                        m("x", r("x")),
-                        m("y", r("y")),
-                        m("z", r("z"))
-                    ),
-                    b("x", i(1)),
-                    b("y", i(2)),
-                    b("z", i(3))
-                )
+        evx(
+            lt(
+                rec(
+                    m("x", r("x")),
+                    m("y", r("y")),
+                    m("z", r("z"))
+                ),
+                b("x", i(1)),
+                b("y", i(2)),
+                b("z", i(3))
             )
         ).toEqual(
             rec(
@@ -58,14 +53,12 @@ describe("eval", () => {
         )
     })
     it("can telescope", () => {
-        expect(
-            evaluate(
-                lt(
-                    a(r("x"), r("y"), r("z")),
-                    b("x", i(1)),
-                    b("y", a(r("x"))),
-                    b("z", a(r("y")))
-                )
+        evx(
+            lt(
+                a(r("x"), r("y"), r("z")),
+                b("x", i(1)),
+                b("y", a(r("x"))),
+                b("z", a(r("y")))
             )
         ).toEqual(
             a(i(1), a(i(1)), a(a(i(1))))
@@ -73,34 +66,28 @@ describe("eval", () => {
     })
     describe("projection", () => {
         it("can project an array", () => {
-            expect(
-                evaluate(
-                    a(i(1), pr(a(i(2), i(3))), i(4))
-                )
+            evx(
+                a(i(1), pr(a(i(2), i(3))), i(4))
             ).toEqual(
                 a(i(1), i(2), i(3), i(4))
             )
         })
         it("can multi-project an array", () => {
-            expect(
-                evaluate(
-                    a(i(1), pr(a(i(2))), i(3), pr(a(i(4))))
-                )
+            evx(
+                a(i(1), pr(a(i(2))), i(3), pr(a(i(4))))
             ).toEqual(a(i(1), i(2), i(3), i(4)))
         })
         it("can project a record", () => {
-            expect(
-                evaluate(
-                    rec(
-                        pr(
-                            rec(
-                                m("x", i(1))
-                            )
-                        ),
-                        pr(
-                            rec(
-                                m("y", i(2))
-                            )
+            evx(
+                rec(
+                    pr(
+                        rec(
+                            m("x", i(1))
+                        )
+                    ),
+                    pr(
+                        rec(
+                            m("y", i(2))
                         )
                     )
                 )
@@ -110,6 +97,110 @@ describe("eval", () => {
                     m("y", i(2))
                 )
             )
+        })
+    })
+    describe("match", () => {
+        it("can match an integer", () => {
+            evx(
+                mtch(
+                    i(1),
+                    cl(i(1), i(2))
+                )
+        ).toEqual(i(2))
+        })
+        it("can match to a variable", () => {
+            evx(
+                mtch(
+                    i(1),
+                    cl(r("x"), r("x"))
+                )
+            ).toEqual(i(1))
+        })
+        it("can match to an array", () => {
+            evx(
+                mtch(
+                    a(i(1), i(2)),
+                    cl(a(i(1), i(2)), i(3))
+                )
+            ).toEqual(i(3))
+        })
+        it("can match variables in an array", () => {
+            evx(
+                mtch(
+                    a(i(1), i(2), i(3)),
+                    cl(a(r("a"), r("b"), r("c")), a(r("c"), r("b"), r("a")))
+                )
+            ).toEqual(a(i(3), i(2), i(1)))
+        })
+        it("can match a record", () => {
+            evx(
+                mtch(
+                    rec(
+                        m("x", i(1)),
+                        m("y", i(2))
+                    ),
+                    cl(
+                        rec(
+                            m("x", r("x")),
+                            m("y", r("y"))
+                        ),
+                        a(r("x"), r("y"))
+                    )
+                )
+            ).toEqual(a(i(1), i(2)))
+        })
+        describe("projection", () => {
+            it("can match a prefix of the array", () => {
+                evx(
+                    mtch(
+                        a(i(1), i(2), i(3)),
+                        cl(
+                            a(i(1), pr(r("x"))),
+                            r("x")
+                        )
+                    )
+                ).toEqual(a(i(2), i(3)))
+            })
+            it("can match the suffix of an array", () => {
+                evx(
+                    mtch(
+                        a(i(1), i(2), i(3)),
+                        cl(
+                            a(pr(r("x")), i(3)),
+                            r("x")
+                        )
+                    )
+                ).toEqual(a(i(1), i(2)))
+            })
+            it("can match the both prefix and suffix", () => {
+                evx(
+                    mtch(
+                        a(i(1), i(2), i(3)),
+                        cl(
+                            a(i(1), pr(r("x")), i(3)),
+                            r("x")
+                        )
+                    )
+                ).toEqual(a(i(2)))
+            })
+            it("can match a projected record", () => {
+                evx(
+                    mtch(
+                        rec(
+                            m("x", i(1)),
+                            m("y", i(2)),
+                            m("z", i(3))
+                        ),
+                        cl(
+                            rec(
+                                m("x", r("x")),
+                                pr(r("rest"))
+                            ),
+                            a(r("x"), r("rest"))
+                        )
+                    )
+                ).toEqual(a(i(1), rec(m("y", i(2)), m("z", i(3)))))
+            })
         })
     })
 })
@@ -204,5 +295,75 @@ function pr(value: Expression): Projection {
     return {
         kind: NodeKind.Projection,
         value
+    }
+}
+
+function mtch(target: Expression, ...clauses: MatchClause[]): Match {
+    return {
+        kind: NodeKind.Match,
+        target,
+        clauses
+    }
+}
+
+function cl(pattern: Expression, value: Expression): MatchClause {
+    return {
+        kind: NodeKind.MatchClause,
+        pattern,
+        value
+    }
+}
+
+function evx(value: Expression): jasmine.Matchers<Expression> {
+    const result = evaluate(value)
+    removeRuntimeCaches(result)
+    return expect(result)
+}
+
+function removeRuntimeCaches(value: Node) {
+    switch (value.kind) {
+        case NodeKind.Literal:
+        case NodeKind.Reference:
+            break
+        case NodeKind.Let:
+            value.bindings.forEach(removeRuntimeCaches)
+            removeRuntimeCaches(value.body)
+            break
+        case NodeKind.Binding:
+            removeRuntimeCaches(value.value)
+            break
+        case NodeKind.Lambda:
+            removeRuntimeCaches(value.body)
+            break
+        case NodeKind.Call:
+            removeRuntimeCaches(value.target)
+            value.args.forEach(removeRuntimeCaches)
+            break
+        case NodeKind.Record:
+            value.members.forEach(removeRuntimeCaches)
+            delete (value as any).map
+            break
+        case NodeKind.Member:
+            removeRuntimeCaches(value.value)
+            break
+        case NodeKind.Array:
+            value.values.forEach(removeRuntimeCaches)
+            break
+        case NodeKind.Select:
+            removeRuntimeCaches(value.target)
+            break
+        case NodeKind.Index:
+            removeRuntimeCaches(value.target)
+            removeRuntimeCaches(value.index)
+            break
+        case NodeKind.Projection:
+            break
+        case NodeKind.Match:
+            removeRuntimeCaches(value.target)
+            value.clauses.forEach(removeRuntimeCaches)
+            break
+        case NodeKind.MatchClause:
+            removeRuntimeCaches(value.value)
+            break
     }
 }

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -1,16 +1,16 @@
-import { Array, Binding, Expression, Lambda, LiteralInt, LiteralKind, Member, NodeKind, Record } from "./ast";
+import { Array, Binding, Expression, Lambda, Literal, LiteralInt, LiteralKind, Member, NodeKind, Projection, Record, Reference } from "./ast";
 
 export function evaluate(expression: Expression): Expression {
 
     function e(scope: Scope, node: Expression): Expression {
         switch (node.kind) {
-            case NodeKind.Literal: 
+            case NodeKind.Literal:
                 return node
-            case NodeKind.Reference: 
+            case NodeKind.Reference:
                 return scope.get(node.name)
-            case NodeKind.Let: 
+            case NodeKind.Let:
                 return e(telescope(scope, node.bindings, e), node.body)
-            case NodeKind.Lambda: 
+            case NodeKind.Lambda:
                 return node
             case NodeKind.Call: {
                 const args = node.args.map(node => e(scope, node))
@@ -38,8 +38,9 @@ export function evaluate(expression: Expression): Expression {
                 }
                 return {
                     kind: NodeKind.Record,
-                    members
-                }
+                    members,
+                    map: memberMap
+                } as Record
             }
             case NodeKind.Array: {
                 const values: Expression[] = []
@@ -58,14 +59,126 @@ export function evaluate(expression: Expression): Expression {
             }
             case NodeKind.Select: {
                 const rec = record(e(scope, node.target))
-                return (rec.members.find(member => (member as Member).name == node.name) ?? error(`Undefined member: ${node.name}`)).value
+                return (rec.map.get(node.name) ?? error(`Undefined member: ${node.name}`))
             }
             case NodeKind.Index: {
                 const target = array(e(scope, node.target))
                 const index = int(e(scope, node.index))
                 return target.values[index.value] as Expression ?? error("Index out of bound")
             }
+            case NodeKind.Match: {
+                const target = e(scope, node.target)
+                for (const clause of node.clauses) {
+                    const valueScope = matches(scope, clause.pattern, target)
+                    if (valueScope) {
+                        return e(valueScope, clause.value)
+                    }
+                }
+                error("No matching match clause found")
+            }
         }
+    }
+
+    function reduce(scope: Scope, value: Expression): Expression {
+        return e({
+            get: name => scope.has(name) ? scope.get(name) : r(name),
+            has: scope.has
+        }, value)
+    }
+
+    function r(name: string): Reference { return { kind: NodeKind.Reference, name }}
+
+    function matches(scope: Scope, pattern: Expression, value: Expression): Scope | undefined {
+        const map = new Map<string, Expression>()
+
+        function match(p: Expression, v: Expression): boolean {
+            if (p.kind == v.kind) {
+                switch (p.kind) {
+                    case NodeKind.Literal: return p.value == (v as Literal).value
+                    case NodeKind.Reference: return false
+                    case NodeKind.Let: error("Let cannot be in a pattern")
+                    case NodeKind.Lambda: error("Lambda cannot be in a pattern")
+                    case NodeKind.Call: error("Call cannot be in a pattern")
+                    case NodeKind.Index: error("Index operator cannot be in pattern")
+                    case NodeKind.Select: error("Selection operator cannot be in a pattern")
+                    case NodeKind.Match: error("Match cannot be in a pattern")
+                    case NodeKind.Array:
+                        const pa = p.values
+                        const ar = (v as Array).values as Expression[]
+                        let projectIndex = -1
+                        for (let i = 0; i < pa.length; i++) {
+                            const pat = pa[i]
+                            if (pat.kind == NodeKind.Projection) {
+                                projectIndex = i;
+                                break
+                            }
+                            if (i >= ar.length || !match(pat, ar[i])) return false
+                        }
+                        if (projectIndex >= 0) {
+                            for (let i = ar.length - 1, j = pa.length - 1; j > projectIndex; j--, i--) {
+                                const pat = pa[j]
+                                if (pat.kind == NodeKind.Projection) {
+                                    error("Only one array projection allowed in a pattern")
+                                }
+                                if (!match(pat, ar[i])) return false
+                            }
+                            const values = ar.slice(projectIndex, ar.length - (pa.length - (projectIndex + 1)))
+                            const projected: Array = {
+                                kind: NodeKind.Array,
+                                values
+                            }
+                            const projection = pa[projectIndex] as Projection
+                            return match(projection.value, projected)
+                        }
+                        return true
+                    case NodeKind.Record: {
+                        const rec = record(v)
+                        const map = rec.map
+                        let seen = new Set<string>()
+                        let projection: Projection | undefined = undefined
+                        for (const memberOrProjection of p.members) {
+                            if (memberOrProjection.kind == NodeKind.Projection) {
+                                if (projection) {
+                                    error("Only one member projection allowed in a pattern")
+                                }
+                                projection = memberOrProjection
+                            } else {
+                                const value = map.get(memberOrProjection.name)
+                                if (!value || !match(memberOrProjection.value, value)) return false
+                                seen.add(memberOrProjection.name)
+                            }
+                        }
+                        if (projection) {
+                            // Bind projection
+                            const boundRecord: Record = {
+                                kind: NodeKind.Record,
+                                members: rec.members.filter(m => m.kind == NodeKind.Member && !seen.has(m.name))
+                            }
+                            return match(projection.value, boundRecord)
+                        }
+                        return true
+                    }
+                }
+            } else {
+                if (p.kind == NodeKind.Reference) {
+                    const current = map.get(p.name)
+                    if (current) {
+                        return match(current, v)
+                    }
+                    map.set(p.name, v)
+                    return true
+                }
+                return false
+            }
+        }
+
+        const doesMatch = match(pattern, value)
+        if (doesMatch) {
+            if (map.size > 0)
+                return scopeFromMap(scope, map)
+            return scope
+        }
+        return undefined
     }
 
     return e(emptyScope, expression)
@@ -74,22 +187,19 @@ export function evaluate(expression: Expression): Expression {
 
 interface Scope {
     get(name: string): Expression
+    has(name: string): boolean
 }
 
 const emptyScope: Scope = {
-    get: name => error(`Undefined symbol "${name}"`)
-}
-
-function scopeWith(parent: Scope, name: string, value: Expression): Scope {
-    return {
-        get:  lname => lname == name ? value : parent.get(name)
-    }
+    get: name => error(`Undefined symbol "${name}"`),
+    has: name => false
 }
 
 function telescope(parent: Scope, bindings: Binding[], block: (scope: Scope, value: Expression) => Expression ): Scope {
     const map = new Map<string, Expression>()
     const scope: Scope = {
-        get: name => map.get(name) ?? parent.get(name)
+        get: name => map.get(name) ?? parent.get(name),
+        has: name => map.has(name) || parent.has(name)
     }
     for (const binding of bindings) {
         const value = block(scope, binding.value)
@@ -103,8 +213,13 @@ function scopeOf(parent: Scope, names: string[], values: Expression[]): Scope {
     for (let i = 0; i < names.length; i++) {
         map.set(names[i], values[i])
     }
+    return scopeFromMap(parent, map)
+}
+
+function scopeFromMap(parent: Scope, map: Map<string, Expression>): Scope {
     return {
-        get: name => map.get(name) ?? parent.get(name)
+        get: name => map.get(name) ?? parent.get(name),
+        has: name => map.has(name) || parent.has(name)
     }
 }
 
@@ -112,8 +227,22 @@ function lambda(value: Expression): Lambda {
    return value.kind == NodeKind.Lambda ? value : error("Invalid: Expected a lambda")
 }
 
-function record(value: Expression): Record {
-    return value.kind == NodeKind.Record ? value : error("Invalid: Expected a record")
+interface RuntimeRecord extends Record {
+    map: Map<string, Expression>
+}
+
+function record(value: Expression): RuntimeRecord {
+    const rec: RuntimeRecord = value.kind == NodeKind.Record ? value as RuntimeRecord : error("Invalid: Expected a record")
+    if ('map' in rec) {
+        return rec as RuntimeRecord
+    }
+    const map = new Map<string, Expression>()
+    for (const memberP of rec.members) {
+        const member = memberP as Member
+        map.set(member.name, member.value)
+    }
+    rec.map = map
+    return rec
 }
 
 function array(value: Expression): Array {

--- a/src/lexer.spec.ts
+++ b/src/lexer.spec.ts
@@ -50,11 +50,14 @@ describe("lexer", () => {
     it("can scan a project", () => {
         l("...", Token.Project)
     })
+    it("can scan a in", () => {
+        l("in", Token.In)
+    })
     it("can scan a let", () => {
         l("let", Token.Let)
     })
-    it("can scan a in", () => {
-        l("in", Token.In)
+    it("can scan match", () => {
+        l("match", Token.Match)
     })
     it("can scan null", () => {
         l("null", Token.Null)

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -70,8 +70,9 @@ export class Lexer {
                     result = Token.Identifier
                     const ident = text.substring(this.start, i)
                     switch (ident) {
-                        case "let": result = Token.Let; break
                         case "in": result = Token.In; break
+                        case "let": result = Token.Let; break
+                        case "match": result = Token.Match; break
                         case "null": result = Token.Null; break
                     }
                     this.value = ident

--- a/src/parser.spec.ts
+++ b/src/parser.spec.ts
@@ -1,4 +1,4 @@
-import { Array, Binding, Call, Expression, Index, Lambda, Let, LiteralFloat, LiteralInt, LiteralKind, LiteralNull, LiteralString, Member, NodeKind, Projection, Record, Reference, Select } from "./ast"
+import { Array, Binding, Call, Expression, Index, Lambda, Let, LiteralFloat, LiteralInt, LiteralKind, LiteralNull, LiteralString, Match, MatchClause, Member, NodeKind, Projection, Record, Reference, Select } from "./ast"
 import { Lexer } from "./lexer"
 import { parse } from "./parser"
 
@@ -101,6 +101,24 @@ describe("parser", () => {
             )
         })
     })
+    describe("match", () => {
+        it("can parse an empty match", () => {
+            expect(p("match e {}")).toEqual(mtch(r("e")))
+        })
+        it("can parse a single match clause", () => {
+            expect(p("match e { a in b }")).toEqual(mtch(r("e"), cl(r("a"), r("b"))))
+        })
+        it("can parse multiple match clauses", () => {
+            expect(p("match e { a in b, c in d, e in f }")).toEqual(
+                mtch(
+                    r("e"),
+                    cl(r("a"), r("b")),
+                    cl(r("c"), r("d")),
+                    cl(r("e"), r("f"))
+                )
+            )
+        })
+    })
     describe("parens", () => {
         it("can parse a paren expression", () => {
             expect(p("(x)")).toEqual(r("x"))
@@ -110,7 +128,8 @@ describe("parser", () => {
 
 function p(text: string): Expression {
     const lexer = new Lexer(text)
-    return parse(lexer, "test")
+    const result = parse(lexer, "test")
+    return result
 }
 
 function i(value: number): LiteralInt {
@@ -225,6 +244,22 @@ function b(name: string, value: Expression): Binding {
 function pr(value: Expression): Projection {
     return {
         kind: NodeKind.Projection,
+        value
+    }
+}
+
+function mtch(target: Expression, ...clauses: MatchClause[]): Match {
+    return {
+        kind: NodeKind.Match,
+        target,
+        clauses
+    }
+}
+
+function cl(pattern: Expression, value: Expression): MatchClause {
+    return {
+        kind: NodeKind.MatchClause,
+        pattern,
         value
     }
 }

--- a/src/token.ts
+++ b/src/token.ts
@@ -17,8 +17,9 @@ export const enum Token {
     LBrace,
     RBrace,
 
-    Let,
     In,
+    Let,
+    Match,
     Null,
 
     EOF,


### PR DESCRIPTION
Add a matching expression that is similar to a switch or case statement.

For example,

    `match e { 1 in "one", 2 in "two", _ in "not one or two" }`

can convert e to a string if it is 1 or 2.

Destructuring and projection or arrays and records can also be used.

For example,

    `match a { [_, ...t] } in t }`

is a way to remove the first element of an array.