### PR TITLE
Fix ambiguities with patterns and values

### DIFF
--- a/src/ast-string.ts
+++ b/src/ast-string.ts
@@ -16,6 +16,8 @@ export function nodeKindString(kind: NodeKind): string {
         case NodeKind.Projection: return "Projection"
         case NodeKind.Match: return "Match"
         case NodeKind.MatchClause: return "MatchClause"
+        case NodeKind.Pattern: return "Pattern"
+        case NodeKind.Variable: return "variable"
     }
 }
 
@@ -50,5 +52,7 @@ export function dump(node: Node): string {
         case NodeKind.Projection: return `...${dump(node.value)}`
         case NodeKind.Match: return `match { ${node.clauses.map(dump).join(", ")} }`
         case NodeKind.MatchClause: return `${dump(node.pattern)} in ${dump(node.value)}`
+        case NodeKind.Pattern: return `P${dump(node.pattern)}`
+        case NodeKind.Variable: return `#${node.name}`
     }
 }

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -13,6 +13,8 @@ export const enum NodeKind {
     Projection,
     Match,
     MatchClause,
+    Pattern,
+    Variable,
 }
 
 export const enum LiteralKind {
@@ -20,6 +22,10 @@ export const enum LiteralKind {
     Float,
     String,
     Null,
+}
+
+export interface NodeLike {
+    kind: NodeKind
 }
 
 export interface LiteralInt {
@@ -81,20 +87,20 @@ export interface Call {
     args: Expression[]
 }
 
-export interface Record {
+export interface Record<M extends NodeLike> {
     kind: NodeKind.Record
-    members: (Member | Projection)[]
+    members: M[]
 }
 
-export interface Member {
+export interface Member<T extends NodeLike> {
     kind: NodeKind.Member
     name: string
-    value: Expression
+    value: T
 }
 
-export interface Array {
+export interface Array<T extends NodeLike> {
     kind: NodeKind.Array
-    values: (Expression | Projection)[]
+    values: T[]
 }
 
 export interface Select {
@@ -109,9 +115,9 @@ export interface Index {
     index: Expression
 }
 
-export interface Projection {
+export interface Projection<T extends NodeLike> {
     kind: NodeKind.Projection
-    value: Expression
+    value: T
 }
 
 export interface Match {
@@ -122,8 +128,19 @@ export interface Match {
 
 export interface MatchClause {
     kind: NodeKind.MatchClause
-    pattern: Expression
+    pattern: Expression | Variable | Pattern
     value: Expression
+}
+
+export interface Variable {
+    kind: NodeKind.Variable
+    name: string
+}
+
+export interface Pattern {
+    kind: NodeKind.Pattern
+    pattern: Array<Expression | Pattern | Variable | Projection<Pattern | Variable>> |
+        Record<Member<Expression |  Pattern | Variable> | Projection<Pattern | Variable>>
 }
 
 export type Expression =
@@ -132,8 +149,8 @@ export type Expression =
     Let |
     Call |
     Lambda |
-    Array |
-    Record |
+    Array<Expression | Projection<Expression>> |
+    Record<Member<Expression> | Projection<Expression>> |
     Select |
     Index |
     Match
@@ -141,6 +158,10 @@ export type Expression =
 export type Node =
     Expression |
     Binding |
-    Member |
-    Projection |
-    MatchClause
+    Member<Expression | Pattern | Variable> |
+    Projection<Expression | Pattern | Variable> |
+    Array<Expression | Pattern | Variable | Projection<Pattern | Variable>> |
+    Record<Member<Expression |  Pattern | Variable> | Projection<Pattern | Variable>> |
+    MatchClause |
+    Pattern |
+    Variable

--- a/src/integration.spec.ts
+++ b/src/integration.spec.ts
@@ -1,4 +1,5 @@
 import { Expression } from "./ast"
+import { evaluate } from "./eval"
 import { evx } from "./eval.spec"
 import { Lexer } from "./lexer"
 import { parse } from "./parser"
@@ -31,8 +32,8 @@ describe("integration tests", () => {
 
 function ex(text: string, result: string) {
     const exp = p(text)
-    const r = p(result)
-    evx(exp).toEqual(r)
+    const r = evaluate(p(result))
+    evx(exp, r)
 }
 
 function p(text: string): Expression {

--- a/src/parser.spec.ts
+++ b/src/parser.spec.ts
@@ -1,4 +1,4 @@
-import { Array, Binding, Call, Expression, Index, Lambda, Let, LiteralFloat, LiteralInt, LiteralKind, LiteralNull, LiteralString, Match, MatchClause, Member, NodeKind, Projection, Record, Reference, Select } from "./ast"
+import { Array, Binding, Call, Expression, Index, Lambda, Let, LiteralFloat, LiteralInt, LiteralKind, LiteralNull, LiteralString, Match, MatchClause, Member, NodeKind, Pattern, Projection, Record, Reference, Select, Variable } from "./ast"
 import { Lexer } from "./lexer"
 import { parse } from "./parser"
 
@@ -106,15 +106,15 @@ describe("parser", () => {
             expect(p("match e {}")).toEqual(mtch(r("e")))
         })
         it("can parse a single match clause", () => {
-            expect(p("match e { a in b }")).toEqual(mtch(r("e"), cl(r("a"), r("b"))))
+            expect(p("match e { a in b }")).toEqual(mtch(r("e"), cl(v("a"), r("b"))))
         })
         it("can parse multiple match clauses", () => {
             expect(p("match e { a in b, c in d, e in f }")).toEqual(
                 mtch(
                     r("e"),
-                    cl(r("a"), r("b")),
-                    cl(r("c"), r("d")),
-                    cl(r("e"), r("f"))
+                    cl(v("a"), r("b")),
+                    cl(v("c"), r("d")),
+                    cl(v("e"), r("f"))
                 )
             )
         })
@@ -187,14 +187,14 @@ function c(target: Expression, ...args: Expression[]): Call {
     }
 }
 
-function rec(...members: (Member | Projection)[]): Record {
+function rec(...members: (Member<Expression> | Projection<Expression>)[]): Record<Member<Expression> | Projection<Expression>> {
     return {
         kind: NodeKind.Record,
         members
     }
 }
 
-function m(name: string, value: Expression): Member {
+function m(name: string, value: Expression): Member<Expression> {
     return {
         kind: NodeKind.Member,
         name,
@@ -202,7 +202,7 @@ function m(name: string, value: Expression): Member {
     }
 }
 
-function a(...values: (Expression | Projection)[]): Array {
+function a(...values: (Expression | Projection<Expression>)[]): Array<Expression | Projection<Expression>> {
     return {
         kind: NodeKind.Array,
         values
@@ -241,7 +241,7 @@ function b(name: string, value: Expression): Binding {
     }
 }
 
-function pr(value: Expression): Projection {
+function pr(value: Expression): Projection<Expression> {
     return {
         kind: NodeKind.Projection,
         value
@@ -256,10 +256,17 @@ function mtch(target: Expression, ...clauses: MatchClause[]): Match {
     }
 }
 
-function cl(pattern: Expression, value: Expression): MatchClause {
+function cl(pattern: Expression | Variable | Pattern, value: Expression): MatchClause {
     return {
         kind: NodeKind.MatchClause,
         pattern,
         value
+    }
+}
+
+function v(name: string): Variable {
+    return {
+        kind: NodeKind.Variable,
+        name
     }
 }


### PR DESCRIPTION
Pattern parsing was ambigious between patterns and expressions
Simplified evaluation by introducing a Value type and modifying
evaluation to return a value subset instead of a full expression.