### PR TITLE
Fix parsing expression in match pattern

### DIFF
--- a/src/integration.spec.ts
+++ b/src/integration.spec.ts
@@ -28,6 +28,20 @@ describe("integration tests", () => {
             }
         `, `{ y: 2, z: 3 }`)
     })
+    it("can use an expression for a pattern", () => {
+        ex(`
+            let 
+              Enum = {
+                A: 1,
+                B: 2,
+              },
+              v = match 1 {
+                 Enum.A in Enum.B,
+                 Enum.B in Enum.A
+              }
+            in v
+        `, `2`)
+    })
 })
 
 function ex(text: string, result: string) {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -8,8 +8,7 @@ export function parse(lexer: Lexer, name: string = "<text>"): Expression {
     expect(Token.EOF)
     return result
 
-    function expression(): Expression {
-        let left = primary()
+    function postfix(left: Expression): Expression {
         while (postfixExprPrefix[token]) {
             switch (token) {
                 case Token.LParen: {
@@ -51,7 +50,13 @@ export function parse(lexer: Lexer, name: string = "<text>"): Expression {
             }
             break
         }
+
         return left
+    }
+   
+    function expression(): Expression {
+        let left = primary()
+        return postfixExprPrefix[token] ? postfix(left) : left
     }
 
     function reference(): Reference {
@@ -304,7 +309,16 @@ export function parse(lexer: Lexer, name: string = "<text>"): Expression {
 
     function matchPattern(): Expression | Pattern | Variable {
         switch(token) {
-            case Token.Identifier:
+            case Token.Identifier: {
+                const name = expectName()
+                return postfixExprPrefix[token] ? postfix({
+                        kind: NodeKind.Reference,
+                        name
+                    }) : {
+                        kind: NodeKind.Variable,
+                        name
+                    }
+            }
             case Token.LBrack:
             case Token.LBrace:
                 return matchVariableOrPattern()


### PR DESCRIPTION
Fix parsing expressions in match patterns where pattern
starts with an identifier