### PR TITLE
Simplified the AST

### DIFF
--- a/src/ast-string.ts
+++ b/src/ast-string.ts
@@ -18,7 +18,6 @@ export function nodeKindString(kind: NodeKind): string {
         case NodeKind.Projection: return "Projection"
         case NodeKind.Match: return "Match"
         case NodeKind.MatchClause: return "MatchClause"
-        case NodeKind.Pattern: return "Pattern"
         case NodeKind.Variable: return "variable"
     }
 }
@@ -58,7 +57,6 @@ export function dump(node: Node): string {
         case NodeKind.Splice: return `$${dump(node.target)}`
         case NodeKind.Match: return `match { ${node.clauses.map(dump).join(", ")} }`
         case NodeKind.MatchClause: return `${dump(node.pattern)} in ${dump(node.value)}`
-        case NodeKind.Pattern: return `P${dump(node.pattern)}`
         case NodeKind.Variable: return `#${node.name}`
     }
 }

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -15,7 +15,6 @@ export const enum NodeKind {
     Projection,
     Match,
     MatchClause,
-    Pattern,
     Variable,
 }
 
@@ -97,20 +96,20 @@ export interface Call {
     args: Expression[]
 }
 
-export interface Record<M extends NodeLike> {
+export interface Record {
     kind: NodeKind.Record
-    members: M[]
+    members: (Member | Projection)[]
 }
 
-export interface Member<T extends NodeLike> {
+export interface Member {
     kind: NodeKind.Member
     name: string
-    value: T
+    value: Expression
 }
 
-export interface Array<T extends NodeLike> {
+export interface Array {
     kind: NodeKind.Array
-    values: T[]
+    values: (Expression | Projection)[]
 }
 
 export interface Select {
@@ -135,9 +134,9 @@ export interface Splice {
     target: Expression
 }
 
-export interface Projection<T extends NodeLike> {
+export interface Projection {
     kind: NodeKind.Projection
-    value: T
+    value: Expression
 }
 
 export interface Match {
@@ -148,7 +147,7 @@ export interface Match {
 
 export interface MatchClause {
     kind: NodeKind.MatchClause
-    pattern: Expression | Variable | Pattern
+    pattern: Expression
     value: Expression
 }
 
@@ -157,33 +156,24 @@ export interface Variable {
     name: string
 }
 
-export interface Pattern {
-    kind: NodeKind.Pattern
-    pattern: Array<Expression | Pattern | Variable | Projection<Pattern | Variable>> |
-        Record<Member<Expression |  Pattern | Variable> | Projection<Pattern | Variable>>
-}
-
 export type Expression =
     Literal |
     Reference |
     Let |
     Call |
     Lambda |
-    Array<Expression | Projection<Expression>> |
-    Record<Member<Expression> | Projection<Expression>> |
+    Array |
+    Record |
     Select |
     Index |
     Quote |
     Splice |
-    Match
+    Match |
+    Projection |
+    Variable
 
 export type Node =
     Expression |
     Binding |
-    Member<Expression | Pattern | Variable> |
-    Projection<Expression | Pattern | Variable> |
-    Array<Expression | Pattern | Variable | Projection<Pattern | Variable>> |
-    Record<Member<Expression |  Pattern | Variable> | Projection<Pattern | Variable>> |
-    MatchClause |
-    Pattern |
-    Variable
+    Member |
+    MatchClause

--- a/src/integration.spec.ts
+++ b/src/integration.spec.ts
@@ -9,22 +9,22 @@ describe("integration tests", () => {
         ex("1", "1")
     })
     it("can evaluate a match", () => {
-        ex("match [1, 2, 3] { [_, ...t] in t }", "[2, 3]")
+        ex("match [1, 2, 3] { [#_, ...#t] in t }", "[2, 3]")
     })
     it("can match as a switch", () => {
-        ex(`match 1 { 1 in "one", 2 in "two", _ in "other" }`, `"one"`)
+        ex(`match 1 { 1 in "one", 2 in "two", #_ in "other" }`, `"one"`)
     })
     it("can destruction a record into an array", () => {
         ex(`
             match { x: 1, y: 2, z: 3 } {
-                { x, y, z } in [z, y, x]
+                { #x, #y, #z } in [z, y, x]
             }
         `, `[3, 2, 1]`)
     })
     it("can extract a member using match", () => {
         ex(`
             match { x: 1, y: 2, z: 3 } {
-                { x, ...rest } in rest
+                { #x, ...#rest } in rest
             }
         `, `{ y: 2, z: 3 }`)
     })
@@ -50,8 +50,8 @@ describe("integration tests", () => {
                     false in else()
                 },
                 eq = /(a, b).match a {
-                    (b) in true,
-                    _ in false
+                    b in true,
+                    #_ in false
                 },
                 t = /(x).if(eq(x, 10), /().10, /().20),
             in [t(10), t(1)]
@@ -85,7 +85,7 @@ describe("integration tests", () => {
                 let
                     eq = /(a,b).match a {
                         (b) in true,
-                        _ in false
+                        #_ in false
                     },
                     a = 1,
                     b = 1
@@ -97,13 +97,13 @@ describe("integration tests", () => {
             ex(`
                 let
                     eq = /(a,b).match a {
-                        (b) in true,
-                        _ in false
+                        b in true,
+                        #_ in false
                     },
                     if = /(cond, then, else).'(
                         match $cond {
                             true in $then,
-                            _ in $else
+                            #_ in $else
                         }
                     )
                 in $(if('true, '42, '43))

--- a/src/lexer.spec.ts
+++ b/src/lexer.spec.ts
@@ -56,6 +56,9 @@ describe("lexer", () => {
     it("can scan a project", () => {
         l("...", Token.Project)
     })
+    it("can scan a hash", () => {
+        l("#", Token.Hash)
+    })
     it("can scan a in", () => {
         l("in", Token.In)
     })
@@ -75,9 +78,9 @@ describe("lexer", () => {
         l("false", Token.False)
     })
     it("can scan adjacent tokens", () => {
-        l("abc(){}[].,:=/$'1.0", Token.Identifier, Token.LParen, Token.RParen, Token.LBrace,
+        l("abc(){}[].,:=/$'#1.0", Token.Identifier, Token.LParen, Token.RParen, Token.LBrace,
             Token.RBrace, Token.LBrack, Token.RBrack, Token.Dot, Token.Comma, Token.Colon, 
-            Token.Equal, Token.Lambda, Token.Dollar, Token.Quote, Token.Float)
+            Token.Equal, Token.Lambda, Token.Dollar, Token.Quote, Token.Hash, Token.Float)
     })
 })
 

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -165,6 +165,9 @@ export class Lexer {
                 case "'":
                     result = Token.Quote
                     break
+                case "#":
+                    result = Token.Hash
+                    break
             }
             break
         }

--- a/src/parser.spec.ts
+++ b/src/parser.spec.ts
@@ -1,4 +1,4 @@
-import { Array, Binding, Call, Expression, Index, Lambda, Let, LiteralFloat, LiteralInt, LiteralKind, LiteralNull, LiteralString, Match, MatchClause, Member, NodeKind, Pattern, Projection, Record, Reference, Select, Variable } from "./ast"
+import { Array, Binding, Call, Expression, Index, Lambda, Let, LiteralFloat, LiteralInt, LiteralKind, LiteralNull, LiteralString, Match, MatchClause, Member, NodeKind, Projection, Record, Reference, Select, Variable } from "./ast"
 import { Lexer } from "./lexer"
 import { parse } from "./parser"
 
@@ -106,10 +106,10 @@ describe("parser", () => {
             expect(p("match e {}")).toEqual(mtch(r("e")))
         })
         it("can parse a single match clause", () => {
-            expect(p("match e { a in b }")).toEqual(mtch(r("e"), cl(v("a"), r("b"))))
+            expect(p("match e { #a in b }")).toEqual(mtch(r("e"), cl(v("a"), r("b"))))
         })
         it("can parse multiple match clauses", () => {
-            expect(p("match e { a in b, c in d, e in f }")).toEqual(
+            expect(p("match e { #a in b, #c in d, #e in f }")).toEqual(
                 mtch(
                     r("e"),
                     cl(v("a"), r("b")),
@@ -187,14 +187,14 @@ function c(target: Expression, ...args: Expression[]): Call {
     }
 }
 
-function rec(...members: (Member<Expression> | Projection<Expression>)[]): Record<Member<Expression> | Projection<Expression>> {
+function rec(...members: (Member | Projection)[]): Record {
     return {
         kind: NodeKind.Record,
         members
     }
 }
 
-function m(name: string, value: Expression): Member<Expression> {
+function m(name: string, value: Expression): Member {
     return {
         kind: NodeKind.Member,
         name,
@@ -202,7 +202,7 @@ function m(name: string, value: Expression): Member<Expression> {
     }
 }
 
-function a(...values: (Expression | Projection<Expression>)[]): Array<Expression | Projection<Expression>> {
+function a(...values: (Expression | Projection)[]): Array {
     return {
         kind: NodeKind.Array,
         values
@@ -241,7 +241,7 @@ function b(name: string, value: Expression): Binding {
     }
 }
 
-function pr(value: Expression): Projection<Expression> {
+function pr(value: Expression): Projection {
     return {
         kind: NodeKind.Projection,
         value
@@ -256,7 +256,7 @@ function mtch(target: Expression, ...clauses: MatchClause[]): Match {
     }
 }
 
-function cl(pattern: Expression | Variable | Pattern, value: Expression): MatchClause {
+function cl(pattern: Expression, value: Expression): MatchClause {
     return {
         kind: NodeKind.MatchClause,
         pattern,

--- a/src/token.ts
+++ b/src/token.ts
@@ -18,6 +18,7 @@ export const enum Token {
     RBrace,
     Dollar,
     Quote,
+    Hash,
 
     False,
     In,


### PR DESCRIPTION
No longer uses the TypeScrip type system to rule out invalid uses of
variable and projection. As ohter operations, such as call and select,
etc., are not ruled out it made the AST overly complicated to rule
these out.